### PR TITLE
redirected all requests to the content folder to keep md files separate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,5 @@ paket-files/
 .idea/
 *.sln.iml
 Test
+
+content/

--- a/src/MIISHandler/Common.cs
+++ b/src/MIISHandler/Common.cs
@@ -43,6 +43,11 @@ namespace MIISHandler
                     return val;
             }
 
+            return GetFieldValueFromConfig(name, defValue);
+        }
+
+        public static string GetFieldValueFromConfig(string name, string defValue)
+        {
             //Retrieve from Web.config using the app-specific prefix or without it if it's not present
             return WebHelper.GetParamValue(WEB_CONFIG_PARAM_PREFIX + name, WebHelper.GetParamValue(name, defValue));
         }

--- a/src/MIISHandler/MIISHandler.csproj
+++ b/src/MIISHandler/MIISHandler.csproj
@@ -31,6 +31,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -39,14 +40,20 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Markdig, Version=0.15.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Markdig.0.15.1\lib\net35\Markdig.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="CSS\GitHub.css" />
@@ -111,7 +118,9 @@
       <DependentUpon>Web.config</DependentUpon>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Content\" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -124,16 +133,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>True</UseIIS>
-          <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>51460</DevelopmentServerPort>
-          <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:51465/</IISUrl>
-          <NTLMAuthentication>False</NTLMAuthentication>
-          <UseCustomServer>False</UseCustomServer>
-          <CustomServerUrl>
-          </CustomServerUrl>
-          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+          <SaveServerSettingsInUserFile>True</SaveServerSettingsInUserFile>
         </WebProjectProperties>
       </FlavorProperties>
     </VisualStudio>

--- a/src/MIISHandler/Web.config
+++ b/src/MIISHandler/Web.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0"?>
 <configuration>
   <appSettings>
-    <add key="sitetitle" value ="MIIS Docs"/>
-    <add key="MIIS:UseMDCaching" value ="1"/>
-    <add key="MIIS:UseEmoji" value="1" />
+    <add key="sitetitle" value="MIIS Docs"/>
+    <add key="MIIS:UseMDCaching" value="1"/>
+    <add key="MIIS:UseEmoji" value="1"/>
     <add key="MIIS:allowDownloading" value="0"/>
     <add key="copyright" value="campusMVP 2017"/>
-    <add key="cssfile" value="~/CSS/github.css" />
+    <add key="cssfile" value="~/CSS/github.css"/>
     <add key="MIIS:TemplateName" value="readthedocs"/>
     <add key="MIIS:Layout" value="main.html"/>
     <add key="MIIS:toc" value="toc.md"/>
@@ -27,10 +27,17 @@
     </handlers>
     <defaultDocument enabled="true">
       <files>
-        <add value="index.md"/>
+        <add value="content/index.md"/>
       </files>
     </defaultDocument>
-      <validation validateIntegratedModeConfiguration="false"/>
+    <!--rewrite needs to be installed from https://www.iis.net/downloads/microsoft/url-rewrite to work in IIS-->
+    <rewrite>
+      <rules>
+        <rule name="contentFolder">
+          <match url="^(?!content/)(.+)"/>
+          <action type="Rewrite" url="content/{R:1}"/>
+        </rule>
+      </rules>
+    </rewrite>
   </system.webServer>
-
 </configuration>

--- a/src/MIISHandler/Web.config
+++ b/src/MIISHandler/Web.config
@@ -35,6 +35,10 @@
       <rules>
         <rule name="contentFolder">
           <match url="^(?!content/)(.+)"/>
+          <conditions>
+            <add matchType="Pattern" input="{R:1}" pattern="CSS/.*" negate="true"/>
+            <add matchType="Pattern" input="{R:1}" pattern="Templates/.*" negate="true"/>
+          </conditions>
           <action type="Rewrite" url="content/{R:1}"/>
         </rule>
       </rules>


### PR DESCRIPTION
I put a redirect in so all requests not to the css or template folder have the content folder prefixed to them. I added this to keep all the markdown out of the directory with the code.